### PR TITLE
fix(client): unregister (old) service worker(s)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ultimate-tic-tac-toe",
-  "version": "0.1.1",
+  "version": "0.2.1",
   "description": "ULTIMATE Tic-Tac-Toe",
   "private": true,
   "scripts": {

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -3,6 +3,8 @@ import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App.jsx';
 // import registerServiceWorker from './registerServiceWorker';
+import { unregister as unregisterServiceWorker } from './registerServiceWorker';
 
 ReactDOM.render(<App />, document.getElementById('root'));
 // registerServiceWorker();
+unregisterServiceWorker();


### PR DESCRIPTION
currently not using a service worker, resulting in old
caches being used and users not getting new versions of
the app

bumping the version retrospectively from 0.1.x to 0.2.x